### PR TITLE
Remove the various get_*_type function and add get_type with enum arg

### DIFF
--- a/gccjit.pxd
+++ b/gccjit.pxd
@@ -37,6 +37,27 @@ cdef extern from "libgccjit.h":
     ctypedef struct gcc_jit_loop:
         pass
 
+    cdef enum gcc_jit_types:
+        GCC_JIT_TYPE_VOID,
+        GCC_JIT_TYPE_VOID_PTR,
+        GCC_JIT_TYPE_CHAR,
+        GCC_JIT_TYPE_SIGNED_CHAR,
+        GCC_JIT_TYPE_UNSIGNED_CHAR,
+        GCC_JIT_TYPE_SHORT,
+        GCC_JIT_TYPE_UNSIGNED_SHORT,
+        GCC_JIT_TYPE_INT,
+        GCC_JIT_TYPE_UNSIGNED_INT,
+        GCC_JIT_TYPE_LONG,
+        GCC_JIT_TYPE_UNSIGNED_LONG,
+        GCC_JIT_TYPE_LONG_LONG,
+        GCC_JIT_TYPE_UNSIGNED_LONG_LONG,
+        GCC_JIT_TYPE_FLOAT,
+        GCC_JIT_TYPE_DOUBLE,
+        GCC_JIT_TYPE_LONG_DOUBLE,
+        GCC_JIT_TYPE_CONST_CHAR_PTR,
+        GCC_JIT_TYPE_SIZE_T,
+        GCC_JIT_TYPE_FILE_PTR
+
     ctypedef void (*gcc_jit_code_callback) (gcc_jit_context *ctxt, void *user_data)
 
     gcc_jit_context * gcc_jit_context_acquire ()
@@ -45,11 +66,8 @@ cdef extern from "libgccjit.h":
     void gcc_jit_context_set_code_factory (gcc_jit_context *ctxt,
                                            gcc_jit_code_callback cb, void *user_data)
 
-    gcc_jit_type *gcc_jit_context_get_void_type (gcc_jit_context *ctxt)
-    gcc_jit_type *gcc_jit_context_get_char_type (gcc_jit_context *ctxt)
-    gcc_jit_type *gcc_jit_context_get_int_type (gcc_jit_context *ctxt)
-    gcc_jit_type *gcc_jit_context_get_float_type (gcc_jit_context *ctxt)
-    gcc_jit_type *gcc_jit_context_get_double_type (gcc_jit_context *ctxt)
+    gcc_jit_type *gcc_jit_context_get_type (gcc_jit_context *ctxt,
+                                            gcc_jit_types type_enum)
 
     gcc_jit_type *gcc_jit_type_get_pointer (gcc_jit_type *type)
     gcc_jit_type *gcc_jit_type_get_const (gcc_jit_type *type)

--- a/gccjit.pyx
+++ b/gccjit.pyx
@@ -50,16 +50,8 @@ cdef class Context:
     def set_int_option(self, opt, val):
         c_api.gcc_jit_context_set_int_option(self._c_ctxt, opt, val)
 
-    def get_void_type(self):
-        return make_type(c_api.gcc_jit_context_get_void_type(self._c_ctxt))
-    def get_char_type(self):
-        return make_type(c_api.gcc_jit_context_get_char_type(self._c_ctxt))
-    def get_int_type(self):
-        return make_type(c_api.gcc_jit_context_get_int_type(self._c_ctxt))
-    def get_float_type(self):
-        return make_type(c_api.gcc_jit_context_get_float_type(self._c_ctxt))
-    def get_double_type(self):
-        return make_type(c_api.gcc_jit_context_get_double_type(self._c_ctxt))
+    def get_type(self, type_enum):
+        return make_type(c_api.gcc_jit_context_get_type(self._c_ctxt, type_enum))
 
     def compile(self):
         cdef c_api.gcc_jit_result *c_result
@@ -293,3 +285,23 @@ BOOL_OPTION_DUMP_INITIAL_GIMPLE = c_api.GCC_JIT_BOOL_OPTION_DUMP_INITIAL_GIMPLE
 BOOL_OPTION_DUMP_SUMMARY = c_api.GCC_JIT_BOOL_OPTION_DUMP_SUMMARY
 BOOL_OPTION_DUMP_EVERYTHING = c_api.GCC_JIT_BOOL_OPTION_DUMP_EVERYTHING
 BOOL_OPTION_KEEP_INTERMEDIATES = c_api.GCC_JIT_BOOL_OPTION_KEEP_INTERMEDIATES
+
+TYPE_VOID = c_api.GCC_JIT_TYPE_VOID
+TYPE_VOID_PTR = c_api.GCC_JIT_TYPE_VOID_PTR
+TYPE_CHAR = c_api.GCC_JIT_TYPE_CHAR
+TYPE_SIGNED_CHAR = c_api.GCC_JIT_TYPE_SIGNED_CHAR
+TYPE_UNSIGNED_CHAR = c_api.GCC_JIT_TYPE_UNSIGNED_CHAR
+TYPE_SHORT = c_api.GCC_JIT_TYPE_SHORT
+TYPE_UNSIGNED_SHORT = c_api.GCC_JIT_TYPE_UNSIGNED_SHORT
+TYPE_INT = c_api.GCC_JIT_TYPE_INT
+TYPE_UNSIGNED_INT = c_api.GCC_JIT_TYPE_UNSIGNED_INT
+TYPE_LONG = c_api.GCC_JIT_TYPE_LONG
+TYPE_UNSIGNED_LONG = c_api.GCC_JIT_TYPE_UNSIGNED_LONG
+TYPE_LONG_LONG = c_api.GCC_JIT_TYPE_LONG_LONG
+TYPE_UNSIGNED_LONG_LONG = c_api.GCC_JIT_TYPE_UNSIGNED_LONG_LONG
+TYPE_FLOAT = c_api.GCC_JIT_TYPE_FLOAT
+TYPE_DOUBLE = c_api.GCC_JIT_TYPE_DOUBLE
+TYPE_LONG_DOUBLE = c_api.GCC_JIT_TYPE_LONG_DOUBLE
+TYPE_CONST_CHAR_PTR = c_api.GCC_JIT_TYPE_CONST_CHAR_PTR
+TYPE_SIZE_T = c_api.GCC_JIT_TYPE_SIZE_T
+TYPE_FILE_PTR = c_api.GCC_JIT_TYPE_FILE_PTR

--- a/test.py
+++ b/test.py
@@ -29,14 +29,14 @@ class JitTests(unittest.TestCase):
                  return i * i;
               }
             """
-            param_i = ctxt.new_param(ctxt.get_int_type(),
+            param_i = ctxt.new_param(ctxt.get_type(gccjit.TYPE_INT),
                                      b'i')
             fn = ctxt.new_function(gccjit.FUNCTION_EXPORTED,
-                                   ctxt.get_int_type(),
+                                   ctxt.get_type(gccjit.TYPE_INT),
                                    b"square",
                                    [param_i])
             fn.add_return(ctxt.new_binary_op(gccjit.BINARY_OP_MULT,
-                                             ctxt.get_int_type(),
+                                             ctxt.get_type(gccjit.TYPE_INT),
                                              param_i, param_i))
 
         for i in range(5):
@@ -65,19 +65,19 @@ class JitTests(unittest.TestCase):
                 return sum;
               }
             """
-            the_type = ctxt.get_int_type()
+            the_type = ctxt.get_type(gccjit.TYPE_INT)
             return_type = the_type
-            param_n = ctxt.new_param(the_type, "n")
+            param_n = ctxt.new_param(the_type, b"n")
             fn = ctxt.new_function(gccjit.FUNCTION_EXPORTED,
                                    return_type,
-                                   "loop_test",
+                                   b"loop_test",
                                    [param_n])
             # Build locals
-            local_i = fn.new_local(the_type, "i")
-            local_sum = fn.new_local(the_type, "sum")
+            local_i = fn.new_local(the_type, b"i")
+            local_sum = fn.new_local(the_type, b"sum")
 
             # Create forward label
-            label_after_loop = fn.new_forward_label("after_loop")
+            label_after_loop = fn.new_forward_label(b"after_loop")
 
             # sum = 0
             fn.add_assignment(local_sum, ctxt.zero(the_type))
@@ -86,7 +86,7 @@ class JitTests(unittest.TestCase):
             fn.add_assignment(local_i, ctxt.zero(the_type))
 
             # label "cond:"
-            label_cond = fn.add_label("cond")
+            label_cond = fn.add_label(b"cond")
 
             # if (i >= n)
             fn.add_conditional(ctxt.new_comparison(gccjit.COMPARISON_GE,


### PR DESCRIPTION
libgccjit.so commit 5de6c0a32cda8eb7838289b6ce240a093b59958a removed various
APIs for getting specific type objects which was replaced by a generic
"get_type" with an enum arg. Update Python API accordingly.

Notes:
I'm not sure about the changes to test.py because it end up crashing with:
.libgccjit.so: internal compiler error: Segmentation fault
0x7fad42a2a0e6 crash_signal
        ../../src/gcc/toplev.c:336
0x7fad426c33c5 gcc::jit::function::add_conditional(gcc::jit::location_, gcc::jit::rvalue_, gcc::jit::label_, gcc::jit::label_)
        ../../src/gcc/jit/internal-api.c:944
0x7fad436a04ba __pyx_pf_6gccjit_8Function_8add_conditional
        /home/simon/projects/pygccjit/gccjit.c:3795
0x7fad436a04ba __pyx_pw_6gccjit_8Function_9add_conditional
        /home/simon/projects/pygccjit/gccjit.c:3766
0x7fad4369f1d8 __pyx_f_6gccjit__c_callback
        /home/simon/projects/pygccjit/gccjit.c:956
0x7fad426c2485 gcc::jit::context::invoke_code_factory()
        ../../src/gcc/jit/internal-api.c:1345

(I'm using Python3.3)
