### PR TITLE
Add support for None to Function.add_conditionals on_false argument

### DIFF
--- a/gccjit.pyx
+++ b/gccjit.pyx
@@ -231,13 +231,14 @@ cdef class Function:
                                                  rvalue._c_rvalue)
 
     def add_conditional(self, RValue boolval,
-                        Label on_true, Label on_false,
+                        Label on_true,
+                        Label on_false=None,
                         loc=None):
         c_api.gcc_jit_function_add_conditional(self._c_function,
                                                NULL,
                                                boolval._c_rvalue,
                                                on_true._c_label,
-                                               on_false._c_label)
+                                               on_false._c_label if on_false else NULL)
 
     def add_label(self, name, loc=None):
         c_label = c_api.gcc_jit_function_add_label(self._c_function,

--- a/test.py
+++ b/test.py
@@ -91,7 +91,7 @@ class JitTests(unittest.TestCase):
             # if (i >= n)
             fn.add_conditional(ctxt.new_comparison(gccjit.COMPARISON_GE,
                                                    local_i, param_n),
-                               label_after_loop, None)
+                               label_after_loop)
 
             # sum += i * i
             fn.add_assignment_op(local_sum,


### PR DESCRIPTION
Add explicit None check with conversion to NULL for the on_false argument.
Additionally add '=None' as a default value for on_false.

Notes:
It turns out Cython allows the Python None value through its arg type checking as valid by default (you can look at __Pyx_ArgTypeTest in the generated code):
https://github.com/cython/cython/wiki/FAQ#why-does-a-function-with-cdefd-parameters-accept-none

So Cython is basically does the following for the on_false argument to add_conditional (and actually any arg with None passed in explicitly):
((__pyx_obj_6gccjit_Label *)PyNone)->_c_label

It might make sense to use "#cython: nonecheck=True" as noted in the FAQ, but I'm not sure how this will affect the cases which you want None to translate into NULL (like in this pull request).
