### PR TITLE
Sync Python bindings with latest C API changes

### DIFF
--- a/gccjit.pyx
+++ b/gccjit.pyx
@@ -1,5 +1,6 @@
 #   Copyright 2013 David Malcolm <dmalcolm@redhat.com>
 #   Copyright 2013 Red Hat, Inc.
+#   Copyright 2014 Simon Feltman <s.feltman@gmail.com>
 #
 #   This is free software: you can redistribute it and/or modify it
 #   under the terms of the GNU General Public License as published by
@@ -18,64 +19,126 @@
 from libc.stdlib cimport malloc, free
 cimport gccjit as c_api
 
-cdef int _c_callback(c_api.gcc_jit_context* c_ctxt, object user_data) except -1:
-    ctxt = <Context>user_data;
-    try:
-        ctxt.code_factory(ctxt)
-    except Exception, exc:
-        ctxt.stored_exception = exc
-        return -1
-    return 0
-    #        c_api.gcc_jit_context_add_error(c_ctxt, "Python exception")
-    #    raise
 
 cdef class Context:
     cdef c_api.gcc_jit_context* _c_ctxt
-    cdef object code_factory
-    cdef object stored_exception
 
-    def __cinit__(self, code_factory):
-        self._c_ctxt = c_api.gcc_jit_context_acquire()
-        self.code_factory = code_factory
-        c_api.gcc_jit_context_set_code_factory(
-            self._c_ctxt,
-            <c_api.gcc_jit_code_callback>_c_callback,
-            <void *>self)
+    def __cinit__(self, acquire=True):
+        if acquire:
+            self._c_ctxt = c_api.gcc_jit_context_acquire()
+        else:
+            self._c_ctxt = NULL
 
     def __dealloc__(self):
         c_api.gcc_jit_context_release(self._c_ctxt)
 
+    def set_str_option(self, opt, val):
+        """set_int_option(self, opt:StrOption, val:str)"""
+        c_api.gcc_jit_context_set_str_option(self._c_ctxt, opt, val)
+
     def set_bool_option(self, opt, val):
+        """set_int_option(self, opt:BoolOption, val:bool)"""
         c_api.gcc_jit_context_set_bool_option(self._c_ctxt, opt, val)
+
     def set_int_option(self, opt, val):
+        """set_int_option(self, opt:IntOption, val:int)"""
         c_api.gcc_jit_context_set_int_option(self._c_ctxt, opt, val)
 
     def get_type(self, type_enum):
-        return make_type(c_api.gcc_jit_context_get_type(self._c_ctxt, type_enum))
+        """get_type(self, type_enum:TypeKind) -> Type"""
+        return Type_from_c(c_api.gcc_jit_context_get_type(self._c_ctxt, type_enum))
+
+    def get_int_type(self, num_bytes, is_signed):
+        """get_int_type(self, num_bytes:int, is_signed:bool) -> Type"""
+        return Type_from_c(c_api.gcc_jit_context_get_int_type(self._c_ctxt, num_bytes, is_signed))
 
     def compile(self):
+        """compile(self) -> Result"""
         cdef c_api.gcc_jit_result *c_result
         c_result = c_api.gcc_jit_context_compile(self._c_ctxt)
         if c_result == NULL:
-            raise self.stored_exception
+            raise Exception(self.get_first_error())
         r = Result()
         r._set_c_ptr(c_result)
         return r
 
-    def new_param(self, Type type_, name, loc=None):
+    def dump_to_file(self, path, update_locations):
+        c_api.gcc_jit_context_dump_to_file(self._c_ctxt, path, update_locations)
+
+    def get_first_error(self):
+        return c_api.gcc_jit_context_get_first_error(self._c_ctxt)
+
+    def new_location(self, filename, line, column):
+        """new_location(self, filename:str, line:int, column:int) -> Location"""
+        cdef c_api.gcc_jit_location *c_loc
+        c_loc = c_api.gcc_jit_context_new_location(self._c_ctxt, filename, line, column)
+        loc = Location()
+        loc._c_location = c_loc
+        return loc
+
+    def new_global(self, Type type_, name, Location loc=None):
+        """new_global(self, type_:Type, name:str, loc:Location=None) -> LValue"""
+        c_lvalue = c_api.gcc_jit_context_new_global(self._c_ctxt,
+                                                    get_c_location(loc),
+                                                    type_._c_type,
+                                                    name)
+        return LValue_from_c(c_lvalue)
+
+    def new_array_type(self, Type element_type, int num_elements, Location loc=None):
+        """new_array_type(self, element_type:Type, num_elements:int, loc:Location=None) -> Type"""
+        c_type = c_api.gcc_jit_context_new_array_type(self._c_ctxt,
+                                                      get_c_location(loc),
+                                                      element_type._c_type,
+                                                      num_elements)
+        return Type_from_c(c_type)
+
+    def new_field(self, Type type_, name, Location loc=None):
+        """new_field(self, type_:Type, name:str, loc:Location=None) -> Field"""
+        c_field = c_api.gcc_jit_context_new_field(self._c_ctxt,
+                                                  get_c_location(loc),
+                                                  type_._c_type,
+                                                  name)
+        field = Field()
+        field._c_field = c_field
+        return field
+
+    def new_struct(self, name, fields, Location loc=None):
+        """new_struct(self, name:str, fields:list, loc:Location=None) -> Struct"""
+        fields = list(fields)
+        cdef int num_fields = len(fields)
+        cdef c_api.gcc_jit_field **c_fields = \
+            <c_api.gcc_jit_field **>malloc(num_fields * sizeof(c_api.gcc_jit_field *))
+
+        if c_fields is NULL:
+            raise MemoryError()
+
+        cdef Field field
+        for i in range(num_fields):
+            field = fields[i]
+            c_fields[i] = field._c_field
+
+        c_struct = c_api.gcc_jit_context_new_struct_type(self._c_ctxt,
+                                                         get_c_location(loc),
+                                                         name,
+                                                         num_fields,
+                                                         c_fields)
+        py_struct = Struct()
+        py_struct._c_struct = c_struct
+        free(c_fields)
+        return py_struct
+
+    def new_param(self, Type type_, name, Location loc=None):
+        """new_param(self, type_:Type, name:str, loc:Location=None) -> Param"""
         c_result = c_api.gcc_jit_context_new_param(self._c_ctxt,
-                                                   NULL,
+                                                   get_c_location(loc),
                                                    type_._c_type,
                                                    name)
-        p = Param()
-        p._c_param = c_result
-        p._c_lvalue = c_api.gcc_jit_param_as_lvalue(c_result)
-        p._c_rvalue = c_api.gcc_jit_param_as_rvalue(c_result)
-        return p
+        return Param_from_c(c_result)
 
     def new_function(self, kind, Type return_type, name, params,
-                     loc=None,
+                     Location loc=None,
                      is_variadic=False):
+        """new_function(self, kind:FunctionKind, return_type:Type, name:str, params:list, loc:Location=None, is_variadic=False) -> Function"""
         cdef Param param
         params = list(params)
         cdef int num_params = len(params)
@@ -87,7 +150,7 @@ cdef class Context:
             param = params[i]
             c_params[i] = param._c_param
         c_function = c_api.gcc_jit_context_new_function(self._c_ctxt,
-                                                        NULL,
+                                                        get_c_location(loc),
                                                         kind,
                                                         return_type._c_type,
                                                         name,
@@ -95,54 +158,129 @@ cdef class Context:
                                                         c_params,
                                                         is_variadic)
         free(c_params)
+        return Function_from_c(c_function)
 
-        f = Function()
-        f._c_function = c_function
-        return f
+    def get_builtin_function(self, name):
+        """get_builtin_function(self, name:str) -> Function"""
+        c_function = c_api.gcc_jit_context_get_builtin_function (self._c_ctxt, name)
+        return Function_from_c(c_function)
 
     def zero(self, Type type_):
+        """zero(self, type_:Type) -> RValue"""
         c_rvalue = c_api.gcc_jit_context_zero(self._c_ctxt,
                                               type_._c_type)
-        if c_rvalue == NULL:
-            raise Exception("foo")
-        result = RValue()
-        result._c_rvalue = c_rvalue
-        return result
+        return RValue_from_c(c_rvalue)
 
     def one(self, Type type_):
+        """one(self, type_:Type) -> RValue"""
         c_rvalue = c_api.gcc_jit_context_one(self._c_ctxt,
                                              type_._c_type)
-        if c_rvalue == NULL:
-            raise Exception("foo")
-        result = RValue()
-        result._c_rvalue = c_rvalue
-        return result
+        return RValue_from_c(c_rvalue)
 
-    def new_binary_op (self, op, Type result_type, RValue a, RValue b,
-                       loc=None):
+    def new_rvalue_from_double(self, Type numeric_type, double value):
+        """new_rvalue_from_double(self, numeric_type:Type, value:float) -> RValue"""
+        c_rvalue = c_api.gcc_jit_context_new_rvalue_from_double(self._c_ctxt,
+                                                                numeric_type._c_type,
+                                                                value)
+        return RValue_from_c(c_rvalue)
+
+    def new_rvalue_from_int(self, Type type_, int value):
+        """new_rvalue_from_int(self, type_:Type, value:int) -> RValue"""
+        c_rvalue = c_api.gcc_jit_context_new_rvalue_from_int(self._c_ctxt,
+                                                             type_._c_type,
+                                                             value)
+        return RValue_from_c(c_rvalue)
+
+    # TODO: cannot use a void pointer here
+    #def new_rvalue_from_ptr(self, Type pointer_type, void *value):
+    #    c_rvalue = c_api.gcc_jit_context_new_rvalue_from_ptr(self._c_ctxt,
+    #                                                         pointer_type._c_type,
+    #                                                         value)
+    #    return RValue_from_c(c_rvalue)
+
+    def null(self, Type pointer_type):
+        """null(self, pointer_type:Type) -> RValue"""
+        c_rvalue = c_api.gcc_jit_context_null(self._c_ctxt,
+                                              pointer_type._c_type)
+        return RValue_from_c(c_rvalue)
+
+    def new_string_literal(self, char *value):
+        """new_string_literal(self, value:str) -> RValue"""
+        c_rvalue = c_api.gcc_jit_context_new_string_literal(self._c_ctxt,
+                                                            value)
+        return RValue_from_c(c_rvalue)
+
+    def new_unary_op(self, op, Type result_type, RValue rvalue, Location loc=None):
+        """new_unary_op(self, op:UnaryOp, result_type:Type, rvalue:RValue, loc:Location=None) -> RValue"""
+        c_rvalue = c_api.gcc_jit_context_new_unary_op (self._c_ctxt,
+                                                       get_c_location(loc),
+                                                       op,
+                                                       result_type._c_type,
+                                                       rvalue._c_rvalue)
+        return RValue_from_c(c_rvalue)
+
+    def new_binary_op(self, op, Type result_type, RValue a, RValue b, Location loc=None):
+        """new_binary_op(self, op:BinaryOp, result_type:Type, a:RValue, b:RValue, loc:Location=None) -> RValue"""
         c_rvalue = c_api.gcc_jit_context_new_binary_op(self._c_ctxt,
-                                                       NULL,
+                                                       get_c_location(loc),
                                                        op,
                                                        result_type._c_type,
                                                        a._c_rvalue,
                                                        b._c_rvalue)
-        if c_rvalue == NULL:
-            raise Exception("foo")
-        result = RValue()
-        result._c_rvalue = c_rvalue
-        return result
+        return RValue_from_c(c_rvalue)
 
-    def new_comparison(self, op, RValue a, RValue b, loc=None):
+    def new_comparison(self, op, RValue a, RValue b, Location loc=None):
+        """new_comparison(self, op:Comparison, a:RValue, b:RValue, loc:Location=None) -> RValue"""
         c_rvalue = c_api.gcc_jit_context_new_comparison(self._c_ctxt,
-                                                        NULL,
+                                                        get_c_location(loc),
                                                         op,
                                                         a._c_rvalue,
                                                         b._c_rvalue)
-        if c_rvalue == NULL:
-            raise Exception("foo")
-        result = RValue()
-        result._c_rvalue = c_rvalue
-        return result
+
+        return RValue_from_c(c_rvalue)
+
+    def new_child_context(self):
+        """new_child_context(self) -> Context"""
+        c_child_ctxt = c_api.gcc_jit_context_new_child_context(self._c_ctxt)
+        if c_child_ctxt == NULL:
+            raise Exception("Unknown error creating child context.")
+
+        py_child_ctxt = Context(acquire=False)
+        py_child_ctxt._c_ctxt = c_child_ctxt
+        return py_child_ctxt
+
+    def new_cast(self, RValue rvalue, Type type_, Location loc=None):
+        """new_cast(self, rvalue:RValue, type_:Type, loc:Location=None) -> RValue"""
+        c_rvalue = c_api.gcc_jit_context_new_cast(self._c_ctxt,
+                                                  get_c_location(loc),
+                                                  rvalue._c_rvalue,
+                                                  type_._c_type)
+        return RValue_from_c(c_rvalue)
+
+
+    def new_call(self, Function func, args, Location loc=None):
+        """new_call(self, func:Function, args:list of RValue, loc:Location=None) -> RValue"""
+        args = list(args)
+        cdef int num_args = len(args)
+        cdef c_api.gcc_jit_rvalue **c_args = \
+            <c_api.gcc_jit_rvalue **>malloc(num_args * sizeof(c_api.gcc_jit_rvalue *))
+        if c_args is NULL:
+            raise MemoryError()
+
+        cdef RValue rvalue
+        for i in range(num_args):
+            rvalue = args[i]
+            c_args[i] = rvalue._c_rvalue
+
+        c_rvalue = c_api.gcc_jit_context_new_call(self._c_ctxt,
+                                                  get_c_location(loc),
+                                                  func._c_function,
+                                                  num_args,
+                                                  c_args)
+
+        free(c_args)
+        return RValue_from_c(c_rvalue)
+
 
 cdef class Result:
     cdef c_api.gcc_jit_result* _c_result
@@ -154,10 +292,21 @@ cdef class Result:
 
     def get_code(self, funcname):
         cdef void *ptr = c_api.gcc_jit_result_get_code(self._c_result, funcname)
-        from ctypes import CFUNCTYPE, c_int
-        type_ = CFUNCTYPE(c_int, c_int) # FIXME
-        callable_ = type_(<long>ptr)
-        return callable_
+        return <unsigned long>ptr
+
+
+cdef class Object:
+    cdef c_api.gcc_jit_object *_c_object
+    pass
+
+cdef Object Object_from_c(c_api.gcc_jit_object *c_object):
+    if c_object == NULL:
+        raise Exception("Unknown error, got bad object")
+
+    py_object = Object()
+    py_object._c_object = c_object
+    return py_object
+
 
 cdef class Type:
     cdef c_api.gcc_jit_type *_c_type
@@ -168,141 +317,294 @@ cdef class Type:
         self._c_type = c_type
 
     def get_pointer(self):
-        return make_type(c_api.gcc_jit_type_get_pointer(self._c_type))
-    def get_const(self):
-        return make_type(c_api.gcc_jit_type_get_const(self._c_type))
+        """get_pointer(self) -> Type"""
+        return Type_from_c(c_api.gcc_jit_type_get_pointer(self._c_type))
 
-cdef make_type(c_api.gcc_jit_type *c_type):
+    def get_const(self):
+        """get_const(self) -> Type"""
+        return Type_from_c(c_api.gcc_jit_type_get_const(self._c_type))
+
+    def get_volatile(self):
+        """get_volatile(self) -> Type"""
+        return Type_from_c(c_api.gcc_jit_type_get_volatile(self._c_type))
+
+    def as_object(self):
+        """as_object(self) -> Object"""
+        return Object_from_c(c_api.gcc_jit_type_as_object(self._c_type))
+
+
+cdef Type_from_c(c_api.gcc_jit_type *c_type):
     t = Type()
     t._set_c_ptr(c_type)
     return t
 
-cdef class Label:
-    cdef c_api.gcc_jit_label* _c_label
+
+cdef class Location:
+    cdef c_api.gcc_jit_location* _c_location
     pass
+
+
+cdef c_api.gcc_jit_location* get_c_location(Location py_location):
+    """Get a C location pointer given a Python object, handling None."""
+    if py_location is None:
+        return NULL
+    else:
+        return py_location._c_location
+
+
+cdef class Field:
+    cdef c_api.gcc_jit_field* _c_field
+    pass
+
+
+cdef class Struct:
+    cdef c_api.gcc_jit_struct* _c_struct
+    pass
+
 
 cdef class RValue:
     cdef c_api.gcc_jit_rvalue* _c_rvalue
     pass
 
+cdef RValue RValue_from_c(c_api.gcc_jit_rvalue *c_rvalue):
+    if c_rvalue == NULL:
+        raise Exception("Unknown error, got bad rvalue")
+
+    py_rvalue = RValue()
+    py_rvalue._c_rvalue = c_rvalue
+    return py_rvalue
+
+
 cdef class LValue(RValue):
     cdef c_api.gcc_jit_lvalue* _c_lvalue
-    pass
+
+    def as_object(self):
+        """as_object(self) -> Object"""
+        return Object_from_c(c_api.gcc_jit_lvalue_as_object(self._c_lvalue))
+
+    def as_rvalue(self):
+        """as_rvalue(self) -> RValue"""
+        return RValue_from_c(c_api.gcc_jit_lvalue_as_rvalue(self._c_lvalue))
+
+cdef LValue LValue_from_c(c_api.gcc_jit_lvalue *c_lvalue):
+    if c_lvalue == NULL:
+        raise Exception("Unknown error, got bad lvalue")
+
+    py_lvalue = LValue()
+    py_lvalue._c_lvalue = c_lvalue
+    py_lvalue._c_rvalue = c_api.gcc_jit_lvalue_as_rvalue(c_lvalue)
+    return py_lvalue
+
 
 cdef class Param(LValue):
     cdef c_api.gcc_jit_param* _c_param
-    pass
+
+    def as_object(self):
+        """as_object(self) -> Object"""
+        return Object_from_c(c_api.gcc_jit_param_as_object(self._c_param))
+
+    def as_lvalue(self):
+        """as_lvalue(self) -> LValue"""
+        return LValue_from_c(c_api.gcc_jit_param_as_lvalue(self._c_param))
+
+    def as_rvalue(self):
+        """as_rvalue(self) -> RValue"""
+        return RValue_from_c(c_api.gcc_jit_param_as_rvalue(self._c_param))
+
+cdef Param Param_from_c(c_api.gcc_jit_param *c_param):
+    if c_param == NULL:
+        raise Exception("Unknown error, got bad param")
+
+    p = Param()
+    p._c_param = c_param
+    p._c_lvalue = c_api.gcc_jit_param_as_lvalue(c_param)
+    p._c_rvalue = c_api.gcc_jit_param_as_rvalue(c_param)
+    return p
+
 
 cdef class Function:
     cdef c_api.gcc_jit_function* _c_function
 
-    def new_local(self, Type type_, name, loc=None):
+    def new_local(self, Type type_, name, Location loc=None):
+        """new_local(self, type_:Type, name:str, loc:Location=None) -> LValue"""
         c_lvalue = c_api.gcc_jit_function_new_local(self._c_function,
-                                                    NULL,
+                                                    get_c_location(loc),
                                                     type_._c_type,
                                                     name)
-        if c_lvalue == NULL:
-            raise Exception("foo")
-        result = LValue()
-        result._c_lvalue = c_lvalue
-        result._c_rvalue = c_api.gcc_jit_lvalue_as_rvalue(c_lvalue)
-        return result
+        return LValue_from_c(c_lvalue)
 
-    def new_forward_label(self, name):
-        c_label = c_api.gcc_jit_function_new_forward_label(self._c_function,
-                                                           name)
-        if c_label == NULL:
+    def new_block(self, name):
+        """new_block(self, name:str) -> Block"""
+        c_block = c_api.gcc_jit_function_new_block(self._c_function,
+                                                   name)
+        if c_block == NULL:
             raise Exception("foo")
-        label = Label()
-        label._c_label = c_label
-        return label
+        block = Block()
+        block._c_block = c_block
+        return block
 
-    def add_assignment(self, LValue lvalue, RValue rvalue, loc=None):
-        c_api.gcc_jit_function_add_assignment(self._c_function,
-                                              NULL,
+    def as_object(self):
+        """as_object(self) -> Object"""
+        c_object = c_api.gcc_jit_function_as_object(self._c_function)
+        return Object_from_c(c_object)
+
+    def get_param(self, index):
+        """get_param(self, index:int) -> Param"""
+        c_param = c_api.gcc_jit_function_get_param (self._c_function, index)
+        return Param_from_c(c_param)
+
+    def dump_to_dot(self, char *path):
+        """dump_to_dot(self, path:str)"""
+        c_api.gcc_jit_function_dump_to_dot (self._c_function,
+                                            path)
+
+cdef Function Function_from_c(c_api.gcc_jit_function *c_function):
+    if c_function == NULL:
+        raise Exception("Unknown error, got bad function")
+    f = Function()
+    f._c_function = c_function
+    return f
+
+
+cdef class Block:
+    cdef c_api.gcc_jit_block* _c_block
+
+    def add_eval(self, RValue rvalue, Location loc=None):
+        """add_eval(self, rvalue:RValue, loc:Location=None)"""
+        c_api.gcc_jit_block_add_eval(self._c_block,
+                                     get_c_location(loc),
+                                     rvalue._c_rvalue)
+
+    def add_assignment(self, LValue lvalue, RValue rvalue, Location loc=None):
+        """add_assignment(self, lvalue:LValue, rvalue:RValue, loc:Location=None)"""
+        c_api.gcc_jit_block_add_assignment(self._c_block,
+                                           get_c_location(loc),
+                                           lvalue._c_lvalue,
+                                           rvalue._c_rvalue)
+
+    def add_assignment_op(self, LValue lvalue, op, RValue rvalue, Location loc=None):
+        """add_assignment(self, lvalue:LValue, op:BinaryOp, rvalue:RValue, loc:Location=None)"""
+        c_api.gcc_jit_block_add_assignment_op(self._c_block,
+                                              get_c_location(loc),
                                               lvalue._c_lvalue,
+                                              op,
                                               rvalue._c_rvalue)
 
-    def add_assignment_op(self, LValue lvalue, op, RValue rvalue, loc=None):
-        c_api.gcc_jit_function_add_assignment_op(self._c_function,
-                                                 NULL,
-                                                 lvalue._c_lvalue,
-                                                 op,
-                                                 rvalue._c_rvalue)
+    def add_comment(self, text, Location loc=None):
+        """add_comment(self, text:str, loc:Location=None)"""
+        c_api.gcc_jit_block_add_comment (self._c_block,
+                                         get_c_location(loc),
+                                         text)
 
-    def add_conditional(self, RValue boolval,
-                        Label on_true,
-                        Label on_false=None,
-                        loc=None):
-        c_api.gcc_jit_function_add_conditional(self._c_function,
-                                               NULL,
-                                               boolval._c_rvalue,
-                                               on_true._c_label,
-                                               on_false._c_label if on_false else NULL)
+    def end_with_conditional(self, RValue boolval,
+                             Block on_true,
+                             Block on_false=None,
+                             Location loc=None):
+        """end_with_conditional(self, on_true:Block, on_false:Block=None, loc:Location=None)"""
+        c_api.gcc_jit_block_end_with_conditional(self._c_block,
+                                                 get_c_location(loc),
+                                                 boolval._c_rvalue,
+                                                 on_true._c_block,
+                                                 on_false._c_block if on_false else NULL)
 
-    def add_label(self, name, loc=None):
-        c_label = c_api.gcc_jit_function_add_label(self._c_function,
-                                                   NULL,
-                                                   name)
-        if c_label == NULL:
-            raise Exception("foo")
-        label = Label()
-        label._c_label = c_label
-        return label
+    def end_with_jump(self, Block target, Location loc=None):
+        """end_with_jump(self, target:Block, loc:Location=None)"""
+        c_api.gcc_jit_block_end_with_jump(self._c_block,
+                                          get_c_location(loc),
+                                          target._c_block)
 
-    def place_forward_label(self, Label label, loc=None):
-        c_api.gcc_jit_function_place_forward_label(self._c_function,
-                                                   NULL,
-                                                   label._c_label)
+    def end_with_return(self, RValue rvalue, loc=None):
+        """end_with_return(self, rvalue:RValue, loc:Location=None)"""
+        c_api.gcc_jit_block_end_with_return(self._c_block,
+                                            get_c_location(loc),
+                                            rvalue._c_rvalue)
 
-    def add_jump(self, Label target, loc=None):
-        c_api.gcc_jit_function_add_jump(self._c_function,
-                                        NULL,
-                                        target._c_label)
+    def end_with_void_return(self, loc=None):
+        """end_with_void_return(self, loc:Location=None)"""
+        c_api.gcc_jit_block_end_with_void_return(self._c_block,
+                                                 get_c_location(loc))
 
-    def add_return(self, RValue rvalue, loc=None):
-        c_api.gcc_jit_function_add_return(self._c_function,
-                                          NULL,
-                                          rvalue._c_rvalue)
+    def as_object(self):
+        """as_object(self) -> Object"""
+        c_object = c_api.gcc_jit_block_as_object(self._c_block)
+        return Object_from_c(c_object)
 
-FUNCTION_EXPORTED = c_api.GCC_JIT_FUNCTION_EXPORTED
-FUNCTION_INTERNAL = c_api.GCC_JIT_FUNCTION_INTERNAL
-FUNCTION_IMPORTED = c_api.GCC_JIT_FUNCTION_IMPORTED
+    def get_function(self):
+        """get_function(self) -> Function"""
+        c_function = c_api.gcc_jit_block_get_function (self._c_block)
+        return Function_from_c(c_function)
 
-BINARY_OP_PLUS = c_api.GCC_JIT_BINARY_OP_PLUS
-BINARY_OP_MINUS = c_api.GCC_JIT_BINARY_OP_MINUS
-BINARY_OP_MULT = c_api.GCC_JIT_BINARY_OP_MULT
 
-COMPARISON_LT = c_api.GCC_JIT_COMPARISON_LT
-COMPARISON_GE = c_api.GCC_JIT_COMPARISON_GE
+cdef class FunctionKind:
+    EXPORTED = c_api.GCC_JIT_FUNCTION_EXPORTED
+    INTERNAL = c_api.GCC_JIT_FUNCTION_INTERNAL
+    IMPORTED = c_api.GCC_JIT_FUNCTION_IMPORTED
+    ALWAYS_INLINE = c_api.GCC_JIT_FUNCTION_ALWAYS_INLINE
 
-STR_OPTION_PROGNAME = c_api.GCC_JIT_STR_OPTION_PROGNAME
 
-INT_OPTION_OPTIMIZATION_LEVEL = c_api.GCC_JIT_INT_OPTION_OPTIMIZATION_LEVEL
+cdef class UnaryOp:
+    MINUS = c_api.GCC_JIT_UNARY_OP_MINUS
+    NEGATE = c_api.GCC_JIT_UNARY_OP_BITWISE_NEGATE
+    LOGICAL_NEGATE = c_api.GCC_JIT_UNARY_OP_LOGICAL_NEGATE
 
-BOOL_OPTION_DEBUGINFO = c_api.GCC_JIT_BOOL_OPTION_DEBUGINFO
-BOOL_OPTION_DUMP_INITIAL_TREE = c_api.GCC_JIT_BOOL_OPTION_DUMP_INITIAL_TREE
-BOOL_OPTION_DUMP_INITIAL_GIMPLE = c_api.GCC_JIT_BOOL_OPTION_DUMP_INITIAL_GIMPLE
-BOOL_OPTION_DUMP_SUMMARY = c_api.GCC_JIT_BOOL_OPTION_DUMP_SUMMARY
-BOOL_OPTION_DUMP_EVERYTHING = c_api.GCC_JIT_BOOL_OPTION_DUMP_EVERYTHING
-BOOL_OPTION_KEEP_INTERMEDIATES = c_api.GCC_JIT_BOOL_OPTION_KEEP_INTERMEDIATES
+cdef class BinaryOp:
+    PLUS = c_api.GCC_JIT_BINARY_OP_PLUS
+    MINUS = c_api.GCC_JIT_BINARY_OP_MINUS
+    MULT = c_api.GCC_JIT_BINARY_OP_MULT
+    DIVIDE = c_api.GCC_JIT_BINARY_OP_DIVIDE
+    MODULO = c_api.GCC_JIT_BINARY_OP_MODULO
+    BITWISE_AND = c_api.GCC_JIT_BINARY_OP_BITWISE_AND
+    BITWISE_XOR = c_api.GCC_JIT_BINARY_OP_BITWISE_XOR
+    BITWISE_OR = c_api.GCC_JIT_BINARY_OP_BITWISE_OR
+    LOGICAL_AND = c_api.GCC_JIT_BINARY_OP_LOGICAL_AND
+    LOGICAL_OR = c_api.GCC_JIT_BINARY_OP_LOGICAL_OR
 
-TYPE_VOID = c_api.GCC_JIT_TYPE_VOID
-TYPE_VOID_PTR = c_api.GCC_JIT_TYPE_VOID_PTR
-TYPE_CHAR = c_api.GCC_JIT_TYPE_CHAR
-TYPE_SIGNED_CHAR = c_api.GCC_JIT_TYPE_SIGNED_CHAR
-TYPE_UNSIGNED_CHAR = c_api.GCC_JIT_TYPE_UNSIGNED_CHAR
-TYPE_SHORT = c_api.GCC_JIT_TYPE_SHORT
-TYPE_UNSIGNED_SHORT = c_api.GCC_JIT_TYPE_UNSIGNED_SHORT
-TYPE_INT = c_api.GCC_JIT_TYPE_INT
-TYPE_UNSIGNED_INT = c_api.GCC_JIT_TYPE_UNSIGNED_INT
-TYPE_LONG = c_api.GCC_JIT_TYPE_LONG
-TYPE_UNSIGNED_LONG = c_api.GCC_JIT_TYPE_UNSIGNED_LONG
-TYPE_LONG_LONG = c_api.GCC_JIT_TYPE_LONG_LONG
-TYPE_UNSIGNED_LONG_LONG = c_api.GCC_JIT_TYPE_UNSIGNED_LONG_LONG
-TYPE_FLOAT = c_api.GCC_JIT_TYPE_FLOAT
-TYPE_DOUBLE = c_api.GCC_JIT_TYPE_DOUBLE
-TYPE_LONG_DOUBLE = c_api.GCC_JIT_TYPE_LONG_DOUBLE
-TYPE_CONST_CHAR_PTR = c_api.GCC_JIT_TYPE_CONST_CHAR_PTR
-TYPE_SIZE_T = c_api.GCC_JIT_TYPE_SIZE_T
-TYPE_FILE_PTR = c_api.GCC_JIT_TYPE_FILE_PTR
+
+cdef class Comparison:
+    EQ = GCC_JIT_COMPARISON_EQ
+    NE = GCC_JIT_COMPARISON_NE
+    LT = GCC_JIT_COMPARISON_LT
+    LE = GCC_JIT_COMPARISON_LE
+    GT = GCC_JIT_COMPARISON_GT
+    GE = GCC_JIT_COMPARISON_GE
+
+
+cdef class StrOption:
+    PROGNAME = c_api.GCC_JIT_STR_OPTION_PROGNAME
+
+
+cdef class IntOption:
+    OPTIMIZATION_LEVEL = c_api.GCC_JIT_INT_OPTION_OPTIMIZATION_LEVEL
+
+
+cdef class BoolOption:
+    DEBUGINFO = c_api.GCC_JIT_BOOL_OPTION_DEBUGINFO
+    DUMP_INITIAL_TREE = c_api.GCC_JIT_BOOL_OPTION_DUMP_INITIAL_TREE
+    DUMP_INITIAL_GIMPLE = c_api.GCC_JIT_BOOL_OPTION_DUMP_INITIAL_GIMPLE
+    DUMP_GENERATED_CODE = c_api.GCC_JIT_BOOL_OPTION_DUMP_GENERATED_CODE
+    DUMP_SUMMARY = c_api.GCC_JIT_BOOL_OPTION_DUMP_SUMMARY
+    DUMP_EVERYTHING = c_api.GCC_JIT_BOOL_OPTION_DUMP_EVERYTHING
+    SELFCHECK_GC = c_api.GCC_JIT_BOOL_OPTION_SELFCHECK_GC
+    KEEP_INTERMEDIATES = c_api.GCC_JIT_BOOL_OPTION_KEEP_INTERMEDIATES
+
+
+cdef class TypeKind:
+    VOID = c_api.GCC_JIT_TYPE_VOID
+    VOID_PTR = c_api.GCC_JIT_TYPE_VOID_PTR
+    CHAR = c_api.GCC_JIT_TYPE_CHAR
+    SIGNED_CHAR = c_api.GCC_JIT_TYPE_SIGNED_CHAR
+    UNSIGNED_CHAR = c_api.GCC_JIT_TYPE_UNSIGNED_CHAR
+    SHORT = c_api.GCC_JIT_TYPE_SHORT
+    UNSIGNED_SHORT = c_api.GCC_JIT_TYPE_UNSIGNED_SHORT
+    INT = c_api.GCC_JIT_TYPE_INT
+    UNSIGNED_INT = c_api.GCC_JIT_TYPE_UNSIGNED_INT
+    LONG = c_api.GCC_JIT_TYPE_LONG
+    UNSIGNED_LONG = c_api.GCC_JIT_TYPE_UNSIGNED_LONG
+    LONG_LONG = c_api.GCC_JIT_TYPE_LONG_LONG
+    UNSIGNED_LONG_LONG = c_api.GCC_JIT_TYPE_UNSIGNED_LONG_LONG
+    FLOAT = c_api.GCC_JIT_TYPE_FLOAT
+    DOUBLE = c_api.GCC_JIT_TYPE_DOUBLE
+    LONG_DOUBLE = c_api.GCC_JIT_TYPE_LONG_DOUBLE
+    CONST_CHAR_PTR = c_api.GCC_JIT_TYPE_CONST_CHAR_PTR
+    SIZE_T = c_api.GCC_JIT_TYPE_SIZE_T
+    FILE_PTR = c_api.GCC_JIT_TYPE_FILE_PTR

--- a/test.py
+++ b/test.py
@@ -16,8 +16,12 @@
 #   <http://www.gnu.org/licenses/>.
 
 import unittest
+import ctypes
 
 import gccjit
+
+int_int_func_type = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_int)
+
 
 class JitTests(unittest.TestCase):
     def test_square(self):
@@ -29,25 +33,29 @@ class JitTests(unittest.TestCase):
                  return i * i;
               }
             """
-            param_i = ctxt.new_param(ctxt.get_type(gccjit.TYPE_INT),
+            param_i = ctxt.new_param(ctxt.get_type(gccjit.TypeKind.INT),
                                      b'i')
-            fn = ctxt.new_function(gccjit.FUNCTION_EXPORTED,
-                                   ctxt.get_type(gccjit.TYPE_INT),
+            fn = ctxt.new_function(gccjit.FunctionKind.EXPORTED,
+                                   ctxt.get_type(gccjit.TypeKind.INT),
                                    b"square",
                                    [param_i])
-            fn.add_return(ctxt.new_binary_op(gccjit.BINARY_OP_MULT,
-                                             ctxt.get_type(gccjit.TYPE_INT),
-                                             param_i, param_i))
+
+            block = fn.new_block(b'entry')
+            block.end_with_return(ctxt.new_binary_op(gccjit.BinaryOp.MULT,
+                                                     ctxt.get_type(gccjit.TypeKind.INT),
+                                                     param_i, param_i))
 
         for i in range(5):
-            ctxt = gccjit.Context(cb)
+            ctxt = gccjit.Context()
+            cb(ctxt)
+
             if 0:
-                ctxt.set_bool_option(gccjit.BOOL_OPTION_DUMP_INITIAL_TREE, True)
-                ctxt.set_bool_option(gccjit.BOOL_OPTION_DUMP_INITIAL_GIMPLE, True)
+                ctxt.set_bool_option(gccjit.BoolOption.DUMP_INITIAL_TREE, True)
+                ctxt.set_bool_option(gccjit.BoolOption.DUMP_INITIAL_GIMPLE, True)
             if 0:
-                ctxt.set_int_option(gccjit.INT_OPTION_OPTIMIZATION_LEVEL, 0)
+                ctxt.set_int_option(gccjit.IntOption.OPTIMIZATION_LEVEL, 0)
             result = ctxt.compile()
-            code = result.get_code(b"square")
+            code = int_int_func_type(result.get_code(b"square"))
             self.assertEqual(code(5), 25)
 
     def test_sum_of_squares(self):
@@ -56,19 +64,20 @@ class JitTests(unittest.TestCase):
             Create this function:
               int loop_test (int n)
               {
-                int i;
+                int i = 0;
                 int sum = 0;
-                for (i = 0; i < n ; i ++)
+                while (i < n)
                 {
                   sum += i * i;
+                  i++;
                 }
                 return sum;
               }
             """
-            the_type = ctxt.get_type(gccjit.TYPE_INT)
+            the_type = ctxt.get_type(gccjit.TypeKind.INT)
             return_type = the_type
             param_n = ctxt.new_param(the_type, b"n")
-            fn = ctxt.new_function(gccjit.FUNCTION_EXPORTED,
+            fn = ctxt.new_function(gccjit.FunctionKind.EXPORTED,
                                    return_type,
                                    b"loop_test",
                                    [param_n])
@@ -76,56 +85,121 @@ class JitTests(unittest.TestCase):
             local_i = fn.new_local(the_type, b"i")
             local_sum = fn.new_local(the_type, b"sum")
 
-            # Create forward label
-            label_after_loop = fn.new_forward_label(b"after_loop")
+            entry_block = fn.new_block(b'entry')
 
             # sum = 0
-            fn.add_assignment(local_sum, ctxt.zero(the_type))
+            entry_block.add_assignment(local_sum, ctxt.zero(the_type))
 
             # i = 0
-            fn.add_assignment(local_i, ctxt.zero(the_type))
+            entry_block.add_assignment(local_i, ctxt.zero(the_type))
 
-            # label "cond:"
-            label_cond = fn.add_label(b"cond")
+            # block "cond:"
+            cond_block = fn.new_block(b"cond")
 
-            # if (i >= n)
-            fn.add_conditional(ctxt.new_comparison(gccjit.COMPARISON_GE,
-                                                   local_i, param_n),
-                               label_after_loop)
+            # FIXME: a bit strange to add a jump instead of fallthrough?
+            entry_block.end_with_jump(cond_block)
+
+            loop_block = fn.new_block(b"loop")
+            after_loop_block = fn.new_block(b"after_loop")
+
+
+            # while (i < n)
+            cond_block.end_with_conditional(ctxt.new_comparison(gccjit.Comparison.LT,
+                                                                 local_i, param_n),
+                                            loop_block,
+                                            after_loop_block)
 
             # sum += i * i
-            fn.add_assignment_op(local_sum,
-                                 gccjit.BINARY_OP_PLUS,
-                                 ctxt.new_binary_op(gccjit.BINARY_OP_MULT,
-                                                    the_type,
-                                                    local_i, local_i))
+            loop_block.add_assignment_op(local_sum,
+                                         gccjit.BinaryOp.PLUS,
+                                         ctxt.new_binary_op(gccjit.BinaryOp.MULT,
+                                                            the_type,
+                                                            local_i, local_i))
 
             # i++
-            fn.add_assignment_op(local_i,
-                                 gccjit.BINARY_OP_PLUS,
-                                 ctxt.one(the_type))
+            loop_block.add_assignment_op(local_i,
+                                         gccjit.BinaryOp.PLUS,
+                                         ctxt.one(the_type))
 
-            # goto label_cond
-            fn.add_jump(label_cond)
-
-            # label "after_loop:"
-            fn.place_forward_label(label_after_loop)
+            # goto cond_block
+            loop_block.end_with_jump(cond_block)
 
             # return sum
-            fn.add_return(local_sum)
+            after_loop_block.end_with_return(local_sum)
 
         for i in range(5):
-            ctxt = gccjit.Context(cb)
+            ctxt = gccjit.Context()
+            cb(ctxt)
             if 0:
-                ctxt.set_bool_option(gccjit.BOOL_OPTION_DUMP_INITIAL_TREE, True)
-                ctxt.set_bool_option(gccjit.BOOL_OPTION_DUMP_INITIAL_GIMPLE, True)
-                ctxt.set_bool_option(gccjit.BOOL_OPTION_DUMP_EVERYTHING, True)
-                ctxt.set_bool_option(gccjit.BOOL_OPTION_KEEP_INTERMEDIATES, True)
+                ctxt.set_bool_option(gccjit.BoolOption.DUMP_INITIAL_TREE, True)
+                ctxt.set_bool_option(gccjit.BoolOption.DUMP_INITIAL_GIMPLE, True)
+                ctxt.set_bool_option(gccjit.BoolOption.DUMP_EVERYTHING, True)
+                ctxt.set_bool_option(gccjit.BoolOption.KEEP_INTERMEDIATES, True)
             if 0:
-                ctxt.set_int_option(gccjit.INT_OPTION_OPTIMIZATION_LEVEL, 3)
+                ctxt.set_int_option(gccjit.IntOption.OPTIMIZATION_LEVEL, 3)
             result = ctxt.compile()
-            code = result.get_code(b"loop_test")
+            code = int_int_func_type(result.get_code(b"loop_test"))
             self.assertEqual(code(10), 285)
+
+    def test_imported_function(self):
+        """
+        void some_fn (const char *name)
+        {
+            static char buffer[1024];
+            snprintf(buffer, sizeof(buffer), "hello %s\n", name);
+        }
+        """
+        ctxt = gccjit.Context()
+
+        void_type = ctxt.get_type(gccjit.TypeKind.VOID)
+        const_char_p = ctxt.get_type(gccjit.TypeKind.CONST_CHAR_PTR)
+        char_type = ctxt.get_type(gccjit.TypeKind.CHAR)
+        char_p = char_type.get_pointer()
+        int_type = ctxt.get_type(gccjit.TypeKind.INT)
+        size_type = ctxt.get_type(gccjit.TypeKind.SIZE_T)
+        buf_type = ctxt.new_array_type(char_type, 1024)
+
+        # extern int snprintf(char *str, size_t size, const char *format, ...);
+        snprintf = ctxt.new_function(gccjit.FunctionKind.IMPORTED,
+                                     int_type,
+                                     b'snprintf',
+                                     [ctxt.new_param(char_p, b's'),
+                                      ctxt.new_param(size_type, b'n'),
+                                      ctxt.new_param(const_char_p, b'format')],
+                                     is_variadic=True)
+
+        # void some_fn (const char *name) {
+        param_name = ctxt.new_param(const_char_p, b'name')
+        func = ctxt.new_function(gccjit.FunctionKind.EXPORTED,
+                                 void_type,
+                                 b'some_fn',
+                                 [param_name])
+
+        # static char buffer[1024];
+        buffer = ctxt.new_global(buf_type, b'buffer')
+
+        # snprintf(buffer, sizeof(buffer), "hello %s\n", name);
+        args = [ctxt.new_cast(buffer.as_rvalue(), char_p),
+                ctxt.new_rvalue_from_int(size_type, 1024),
+                ctxt.new_string_literal(b'hello %s\n'),
+                param_name.as_rvalue()]
+
+        block = func.new_block(b'entry')
+        block.add_eval(ctxt.new_call(snprintf, args))
+        block.end_with_void_return()
+
+        ctxt.set_bool_option(gccjit.BoolOption.DUMP_INITIAL_TREE, True)
+        ctxt.set_bool_option(gccjit.BoolOption.DUMP_INITIAL_GIMPLE, True)
+        ctxt.set_bool_option(gccjit.BoolOption.DUMP_EVERYTHING, True)
+        ctxt.set_bool_option(gccjit.BoolOption.KEEP_INTERMEDIATES, True)
+
+        """ FIXME: Compilation is crashing...
+        result = ctxt.compile()
+        py_func_type = ctypes.CFUNCTYPE(None, ctypes.c_char_p)
+        py_func = py_func_type(result.get_code(b'some_fn'))
+        py_func(b'blah')
+        """
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add gcc_jit_object, block, field, and struct wrappers.
Remove gcc_jit_label and loop.

Add doc strings to all functions, currently only show the function
signature.

Clean up some redundant value creation code by adding: RValue_from_c
and similar variations.

Change Result.get_code() to return an unsigned long back to Python.
This way we can wrap different ctypes call signatures around the
resulting pointer.

Attempt to keep order of definitions in gccjit.pxd the same as
they are defined in gccjit.h.
Add all gcc_jit_comparison enum values.

Nest all enum values under named classes.
